### PR TITLE
Add support for #rgba and #rrggbbaa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ $ npm install color-string
 ### Parsing
 
 ```js
-colorString.getRgb("#FFF")  // [255, 255, 255]
-colorString.getRgb("blue")  // [0, 0, 255]
+colorString.getRgb("blue")                       // [0, 0, 255]
+colorString.getRgb("#FFF")                       // [255, 255, 255]
+colorString.getRgba("#FFFA")                     //[255, 255, 255, 0.67]}
+colorString.getRgba("#FFFFFFAA")                 // [255, 255, 255, 0.67]}
 
 colorString.getRgba("rgba(200, 60, 60, 0.3)")    // [200, 60, 60, 0.3]
 colorString.getRgba("rgb(200, 200, 200)")        // [200, 200, 200, 1]
@@ -33,6 +35,8 @@ colorString.getAlpha("rgba(200, 0, 12, 0.6)")    // 0.6
 
 ```js
 colorString.hexString([255, 255, 255])   // "#FFFFFF"
+colorString.hexString([0, 0, 255, 0.4])    // "#0000FF66"
+colorString.hexString([0, 0, 255], 0.4)    // "#0000FF66"
 colorString.rgbString([255, 255, 255])   // "rgb(255, 255, 255)"
 colorString.rgbString([0, 0, 255, 0.4])  // "rgba(0, 0, 255, 0.4)"
 colorString.rgbString([0, 0, 255], 0.4)  // "rgba(0, 0, 255, 0.4)"

--- a/color-string.js
+++ b/color-string.js
@@ -24,25 +24,34 @@ function getRgba(string) {
    if (!string) {
       return;
    }
-   var abbr =  /^#([a-fA-F0-9]{3})$/i,
-       hex =  /^#([a-fA-F0-9]{6})$/i,
+   var abbr =  /^#([a-fA-F0-9]{3,4})$/i,
+       hex =  /^#([a-fA-F0-9]{6}([a-fA-F0-9]{2})?)$/i,
        rgba = /^rgba?\(\s*([+-]?\d+)\s*,\s*([+-]?\d+)\s*,\s*([+-]?\d+)\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)$/i,
        per = /^rgba?\(\s*([+-]?[\d\.]+)\%\s*,\s*([+-]?[\d\.]+)\%\s*,\s*([+-]?[\d\.]+)\%\s*(?:,\s*([+-]?[\d\.]+)\s*)?\)$/i,
        keyword = /(\w+)/;
 
    var rgb = [0, 0, 0],
        a = 1,
-       match = string.match(abbr);
+       match = string.match(abbr),
+       hexAlpha = "";
    if (match) {
       match = match[1];
+      hexAlpha = match[3];
       for (var i = 0; i < rgb.length; i++) {
          rgb[i] = parseInt(match[i] + match[i], 16);
       }
+      if (hexAlpha) {
+         a = Math.round((parseInt(hexAlpha + hexAlpha, 16) / 255) * 100) / 100;
+      }
    }
    else if (match = string.match(hex)) {
+      hexAlpha = match[2];
       match = match[1];
       for (var i = 0; i < rgb.length; i++) {
          rgb[i] = parseInt(match.slice(i * 2, i * 2 + 2), 16);
+      }
+      if (hexAlpha) {
+         a = Math.round((parseInt(hexAlpha, 16) / 255) * 100) / 100;
       }
    }
    else if (match = string.match(rgba)) {
@@ -136,9 +145,16 @@ function getAlpha(string) {
 }
 
 // generators
-function hexString(rgb) {
-   return "#" + hexDouble(rgb[0]) + hexDouble(rgb[1])
-              + hexDouble(rgb[2]);
+function hexString(rgba, a) {
+   var a = (a !== undefined && rgba.length === 3) ? a : rgba[3];
+   return "#" + hexDouble(rgba[0]) 
+              + hexDouble(rgba[1])
+              + hexDouble(rgba[2])
+              + (
+                 (a >= 0 && a < 1)
+                 ? hexDouble(Math.round(a * 255))
+                 : ""
+              );
 }
 
 function rgbString(rgba, alpha) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -108,5 +108,3 @@ assert.equal(string.hwbString([280, 40, 60], 0), "hwb(280, 40%, 60%, 0)");
 
 assert.equal(string.keyword([255, 255, 0]), "yellow");
 assert.equal(string.keyword([100, 255, 0]), undefined);
-
-console.log("Succes");

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,13 +3,7 @@ var assert = require("assert");
 
 
 assert.deepEqual(string.getRgba("#fef"), [255, 238, 255, 1]);
-assert.deepEqual(string.getRgba("#feff"), [255, 238, 255, 1]);
-assert.deepEqual(string.getRgba("#fef0"), [255, 238, 255, 0]);
-assert.deepEqual(string.getRgba("#fefa"), [255, 238, 255, 0.67]);
-assert.deepEqual(string.getRgba("#fffFEF"), [255, 255, 239,1]);
-assert.deepEqual(string.getRgba("#fffFEFfe"), [255, 255, 239, 1]);
-assert.deepEqual(string.getRgba("#fffFEF00"), [255, 255, 239, 0]);
-assert.deepEqual(string.getRgba("#fffFEFa9"), [255, 255, 239, 0.66]);
+assert.deepEqual(string.getRgba("#fffFEF"), [255, 255, 239, 1]);
 assert.deepEqual(string.getRgba("rgb(244, 233, 100)"), [244, 233, 100, 1]);
 assert.deepEqual(string.getRgba("rgb(100%, 30%, 90%)"), [255, 77, 229, 1]);
 assert.deepEqual(string.getRgba("transparent"), [0, 0, 0, 0]);
@@ -39,6 +33,9 @@ assert.equal(string.getAlpha("hwb(244, 100%, 100%, 0.6)"), 0.6);
 assert.equal(string.getAlpha("hwb(244, 100%, 100%)"), 1);
 
 // alpha
+assert.deepEqual(string.getRgba("#feff"), [255, 238, 255, 1]);
+assert.deepEqual(string.getRgba("#fef0"), [255, 238, 255, 0]);
+assert.deepEqual(string.getRgba("#fefa"), [255, 238, 255, 0.67]);
 assert.deepEqual(string.getRgba("#c814e933"), [200, 20, 233, 0.2]);
 assert.deepEqual(string.getRgba("#c814e900"), [200, 20, 233, 0]);
 assert.deepEqual(string.getRgba("#c814e9ff"), [200, 20, 233, 1]);

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,9 +1,15 @@
-var string = require("../color-string"),
-    assert = require("assert");
+var string = require("../color-string");
+var assert = require("assert");
 
 
 assert.deepEqual(string.getRgba("#fef"), [255, 238, 255, 1]);
+assert.deepEqual(string.getRgba("#feff"), [255, 238, 255, 1]);
+assert.deepEqual(string.getRgba("#fef0"), [255, 238, 255, 0]);
+assert.deepEqual(string.getRgba("#fefa"), [255, 238, 255, 0.67]);
 assert.deepEqual(string.getRgba("#fffFEF"), [255, 255, 239,1]);
+assert.deepEqual(string.getRgba("#fffFEFfe"), [255, 255, 239, 1]);
+assert.deepEqual(string.getRgba("#fffFEF00"), [255, 255, 239, 0]);
+assert.deepEqual(string.getRgba("#fffFEFa9"), [255, 255, 239, 0.66]);
 assert.deepEqual(string.getRgba("rgb(244, 233, 100)"), [244, 233, 100, 1]);
 assert.deepEqual(string.getRgba("rgb(100%, 30%, 90%)"), [255, 77, 229, 1]);
 assert.deepEqual(string.getRgba("transparent"), [0, 0, 0, 0]);
@@ -33,6 +39,9 @@ assert.equal(string.getAlpha("hwb(244, 100%, 100%, 0.6)"), 0.6);
 assert.equal(string.getAlpha("hwb(244, 100%, 100%)"), 1);
 
 // alpha
+assert.deepEqual(string.getRgba("#c814e933"), [200, 20, 233, 0.2]);
+assert.deepEqual(string.getRgba("#c814e900"), [200, 20, 233, 0]);
+assert.deepEqual(string.getRgba("#c814e9ff"), [200, 20, 233, 1]);
 assert.deepEqual(string.getRgba("rgba(200, 20, 233, 0.2)"), [200, 20, 233, 0.2]);
 assert.deepEqual(string.getRgba("rgba(200, 20, 233, 0)"), [200, 20, 233, 0]);
 assert.deepEqual(string.getRgba("rgba(100%, 30%, 90%, 0.2)"), [255, 77, 229, 0.2]);
@@ -43,8 +52,8 @@ assert.deepEqual(string.getHwb("hwb(200, 20%, 33%, 0.2)"), [200, 20, 33, 0.2]);
 assert.deepEqual(string.getRgb("#fef"), [255, 238, 255]);
 assert.deepEqual(string.getRgb("rgba(200, 20, 233, 0.2)"), [200, 20, 233]);
 assert.deepEqual(string.getHsl("hsl(240, 100%, 50.5%)"), [240, 100, 50.5]);
-assert.deepEqual(string.getRgba('rgba(0,0,0,0)'), [0, 0, 0, 0]);
-assert.deepEqual(string.getHsla('hsla(0,0%,0%,0)'), [0, 0, 0, 0]);
+assert.deepEqual(string.getRgba("rgba(0,0,0,0)"), [0, 0, 0, 0]);
+assert.deepEqual(string.getHsla("hsla(0,0%,0%,0)"), [0, 0, 0, 0]);
 assert.deepEqual(string.getHwb("hwb(400, 10%, 200%, 0)"), [360, 10, 100, 0]);
 
 // range
@@ -57,9 +66,20 @@ assert.deepEqual(string.getHwb("hwb(400, 10%, 200%, 10)"), [360, 10, 100, 1]);
 assert.strictEqual(string.getRgba("yellowblue"), undefined);
 assert.strictEqual(string.getRgba("hsl(100, 10%, 10%)"), undefined);
 assert.strictEqual(string.getRgba("hwb(100, 10%, 10%)"), undefined);
+assert.strictEqual(string.getRgba("#1"), undefined);
+assert.strictEqual(string.getRgba("#f"), undefined);
+assert.strictEqual(string.getRgba("#4f"), undefined);
+assert.strictEqual(string.getRgba("#45ab4"), undefined);
+assert.strictEqual(string.getRgba("#45ab45e"), undefined);
 
 // generators
 assert.equal(string.hexString([255, 10, 35]), "#FF0A23");
+assert.equal(string.hexString([255, 10, 35, 1]), "#FF0A23");
+assert.equal(string.hexString([255, 10, 35], 1), "#FF0A23");
+assert.equal(string.hexString([255, 10, 35, 0.3]), "#FF0A234D");
+assert.equal(string.hexString([255, 10, 35], 0.3), "#FF0A234D");
+assert.equal(string.hexString([255, 10, 35, 0]), "#FF0A2300");
+assert.equal(string.hexString([255, 10, 35], 0), "#FF0A2300");
 
 assert.equal(string.rgbString([255, 10, 35]), "rgb(255, 10, 35)");
 assert.equal(string.rgbString([255, 10, 35, 0.3]), "rgba(255, 10, 35, 0.3)");
@@ -91,3 +111,5 @@ assert.equal(string.hwbString([280, 40, 60], 0), "hwb(280, 40%, 60%, 0)");
 
 assert.equal(string.keyword([255, 255, 0]), "yellow");
 assert.equal(string.keyword([100, 255, 0]), undefined);
+
+console.log("Succes");


### PR DESCRIPTION
As discussed in https://github.com/chartjs/Chart.js/issues/5152.
Based on https://github.com/Qix-/color-string/commit/88a8282638afdb1fdc4841b5ceca396690bb8b00